### PR TITLE
Update Nginx proxy_pass IP address for EC2 instance

### DIFF
--- a/nginx/home
+++ b/nginx/home
@@ -35,7 +35,7 @@ server {
 
 	# Proxy設定
 	location / {
-		proxy_pass http://15.152.80.220:5000;
+		proxy_pass http://15.152.167.221:5000;
 		proxy_http_version 1.1;
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection "upgrade";


### PR DESCRIPTION
Change the proxy_pass IP address in the Nginx configuration to reflect the new EC2 instance address.